### PR TITLE
Add tablesPrefix option

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -2,23 +2,20 @@ import { Connection, createPool, PoolConnection, ResultSetHeader, RowDataPacket 
 import { DbAddJobsParams, DbCreateQueueParams, DbUpdateQueueParams } from "./types";
 import { Logger } from "./logger";
 
-export const TABLES_NAME_PREFIX = "mysql_queue_";
-export const TABLE_MIGRATIONS = TABLES_NAME_PREFIX + "migrations";
-export const TABLE_QUEUES = TABLES_NAME_PREFIX + "queues";
-export const TABLE_JOBS = TABLES_NAME_PREFIX + "jobs";
+const TABLES_NAME_PREFIX = "mysql_queue_";
 
 export type Database = ReturnType<typeof Database>;
 
-export function Database(logger: Logger, options: { uri: string }) {
+export function Database(logger: Logger, options: { uri: string; tablesPrefix?: string }) {
   const pool = createPool({ uri: options.uri, waitForConnections: true });
 
   const migrations = [
     {
-      down: `DROP TABLE IF EXISTS ${TABLE_QUEUES}`,
+      down: `DROP TABLE IF EXISTS ${queuesTable()}`,
       name: "create-queues-table",
       number: 1,
       up: `
-        CREATE TABLE IF NOT EXISTS ${TABLE_QUEUES} (
+        CREATE TABLE IF NOT EXISTS ${queuesTable()} (
           id CHAR(36) NOT NULL PRIMARY KEY,
           name VARCHAR(50) NOT NULL UNIQUE,
           maxRetries INT UNSIGNED NOT NULL,
@@ -28,11 +25,11 @@ export function Database(logger: Logger, options: { uri: string }) {
           INDEX idx_name (name))`,
     },
     {
-      down: `DROP TABLE IF EXISTS ${TABLE_JOBS}`,
+      down: `DROP TABLE IF EXISTS ${jobsTable()}`,
       name: "create-jobs-table",
       number: 2,
       up: `
-      CREATE TABLE IF NOT EXISTS ${TABLE_JOBS} (
+      CREATE TABLE IF NOT EXISTS ${jobsTable()} (
         id CHAR(36) NOT NULL PRIMARY KEY,
         name VARCHAR(50) NOT NULL,
         payload JSON NOT NULL,
@@ -67,13 +64,13 @@ export function Database(logger: Logger, options: { uri: string }) {
         const values = params.flatMap((job) => [job.id, job.name, job.payload, job.status, job.priority, job.startAfter]);
 
         const [{ affectedRows }] = await conn.query<ResultSetHeader>(
-          `INSERT INTO ${TABLE_JOBS} (id, name, payload, status, priority, startAfter, queueId)
+          `INSERT INTO ${jobsTable()} (id, name, payload, status, priority, startAfter, queueId)
            SELECT j.*, q.id
            FROM (SELECT ? AS id, ? AS name, ? AS payload, ? AS status, ? AS priority, ? AS startAfter ${params
              .slice(1)
              .map(() => "UNION ALL SELECT ?, ?, ?, ?, ?, ?")
              .join(" ")}) AS j
-          JOIN ${TABLE_QUEUES} q ON q.name = ?`,
+          JOIN ${queuesTable()} q ON q.name = ?`,
           [...values, queueName],
         );
         if (affectedRows === 0) throw new Error("Failed to add jobs, maybe queue does not exist");
@@ -84,7 +81,7 @@ export function Database(logger: Logger, options: { uri: string }) {
     async createQueue(params: DbCreateQueueParams) {
       await withConnection((connection) => {
         return connection.query(
-          `INSERT INTO ${TABLE_QUEUES} (id, name, maxRetries, minDelayMs, backoffMultiplier, maxDurationMs) VALUES (?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO ${queuesTable()} (id, name, maxRetries, minDelayMs, backoffMultiplier, maxDurationMs) VALUES (?, ?, ?, ?, ?, ?)`,
           [params.id, params.name, params.maxRetries, params.minDelayMs, params.backoffMultiplier, params.maxDurationMs],
         );
       });
@@ -94,14 +91,14 @@ export function Database(logger: Logger, options: { uri: string }) {
     },
     async getJobById(jobId: string) {
       const [rows] = await withConnection((connection) =>
-        connection.query<RowDataPacket[]>(`SELECT * FROM ${TABLE_JOBS} WHERE id = ?`, [jobId]),
+        connection.query<RowDataPacket[]>(`SELECT * FROM ${jobsTable()} WHERE id = ?`, [jobId]),
       );
       return rows.length ? rows[0] : null;
     },
     async getPendingJobs(queueId: string, batchSize: number) {
       const [rows] = await withConnection((connection) =>
         connection.query<RowDataPacket[]>(
-          `SELECT * FROM ${TABLE_JOBS} WHERE status = ? AND queueId = ? AND (startAfter IS NULL OR startAfter <= ?) ORDER BY priority ASC, createdAt ASC LIMIT ? FOR UPDATE SKIP LOCKED`,
+          `SELECT * FROM ${jobsTable()} WHERE status = ? AND queueId = ? AND (startAfter IS NULL OR startAfter <= ?) ORDER BY priority ASC, createdAt ASC LIMIT ? FOR UPDATE SKIP LOCKED`,
           ["pending", queueId, new Date(), batchSize],
         ),
       );
@@ -109,26 +106,27 @@ export function Database(logger: Logger, options: { uri: string }) {
     },
     async getQueueByName(name: string) {
       const [rows] = await withConnection((connection) =>
-        connection.query<RowDataPacket[]>(`SELECT * FROM ${TABLE_QUEUES} WHERE name = ?`, [name]),
+        connection.query<RowDataPacket[]>(`SELECT * FROM ${queuesTable()} WHERE name = ?`, [name]),
       );
       return rows.length ? rows[0] : null;
     },
     async getQueueIdByName(name: string) {
       const [rows] = await withConnection((connection) =>
-        connection.query<RowDataPacket[]>(`SELECT id FROM ${TABLE_QUEUES} WHERE name = ?`, [name]),
+        connection.query<RowDataPacket[]>(`SELECT id FROM ${queuesTable()} WHERE name = ?`, [name]),
       );
       return rows.length ? (rows[0] as { id: string }) : null;
     },
     async incrementJobAttempts(connection: PoolConnection, jobId: string, error: string, currentAttempts: number, startAfter: Date) {
-      await connection.execute(`UPDATE ${TABLE_JOBS} SET attempts = ?, latestFailureReason = ?, startAfter = ? WHERE id = ?`, [
+      await connection.execute(`UPDATE ${jobsTable()} SET attempts = ?, latestFailureReason = ?, startAfter = ? WHERE id = ?`, [
         currentAttempts + 1,
         error,
         startAfter,
         jobId,
       ]);
     },
+    jobsTable,
     async markJobAsCompleted(connection: PoolConnection, jobId: string, currentAttempts: number) {
-      await connection.execute(`UPDATE ${TABLE_JOBS} SET attempts = ?, status = ?, completedAt = ? WHERE id = ?`, [
+      await connection.execute(`UPDATE ${jobsTable()} SET attempts = ?, status = ?, completedAt = ? WHERE id = ?`, [
         currentAttempts + 1,
         "completed",
         new Date(),
@@ -136,7 +134,7 @@ export function Database(logger: Logger, options: { uri: string }) {
       ]);
     },
     async markJobAsFailed(connection: PoolConnection, jobId: string, error: string, currentAttempts: number) {
-      await connection.execute(`UPDATE ${TABLE_JOBS} SET attempts = ?, status = ?, failedAt = ?, latestFailureReason = ? WHERE id = ?`, [
+      await connection.execute(`UPDATE ${jobsTable()} SET attempts = ?, status = ?, failedAt = ?, latestFailureReason = ? WHERE id = ?`, [
         currentAttempts + 1,
         "failed",
         new Date(),
@@ -144,11 +142,13 @@ export function Database(logger: Logger, options: { uri: string }) {
         jobId,
       ]);
     },
+    migrationsTable,
+    queuesTable,
     async removeAllTables() {
       const connection = await pool.getConnection();
       await connection.beginTransaction();
       try {
-        const [rows] = await connection.query<RowDataPacket[]>(`SELECT name FROM ${TABLE_MIGRATIONS}`);
+        const [rows] = await connection.query<RowDataPacket[]>(`SELECT name FROM ${migrationsTable()}`);
         const appliedMigrations = new Set(rows.map((row) => row.name));
         for (const migration of migrations) {
           if (appliedMigrations.has(migration.name)) {
@@ -157,7 +157,7 @@ export function Database(logger: Logger, options: { uri: string }) {
           }
         }
 
-        await connection.query(`DROP TABLE IF EXISTS ${TABLE_MIGRATIONS}`);
+        await connection.query(`DROP TABLE IF EXISTS ${migrationsTable()}`);
 
         await connection.commit();
       } catch (error) {
@@ -172,10 +172,10 @@ export function Database(logger: Logger, options: { uri: string }) {
       const connection = await pool.getConnection();
       await connection.beginTransaction();
       try {
-        const [migrationTableRows] = await connection.query<RowDataPacket[]>(`SHOW TABLES like '${TABLE_MIGRATIONS}'`);
+        const [migrationTableRows] = await connection.query<RowDataPacket[]>(`SHOW TABLES like '${migrationsTable()}'`);
         if (!migrationTableRows.length) {
           await connection.query(`
-          CREATE TABLE IF NOT EXISTS ${TABLE_MIGRATIONS} (
+          CREATE TABLE IF NOT EXISTS ${migrationsTable()} (
           id INT AUTO_INCREMENT PRIMARY KEY,
           name VARCHAR(255) NOT NULL UNIQUE,
           applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -183,13 +183,13 @@ export function Database(logger: Logger, options: { uri: string }) {
         )`);
         }
 
-        const [appliedMigrationsRows] = await connection.query<RowDataPacket[]>(`SELECT name FROM ${TABLE_MIGRATIONS}`);
+        const [appliedMigrationsRows] = await connection.query<RowDataPacket[]>(`SELECT name FROM ${migrationsTable()}`);
         const appliedMigrations = new Set(appliedMigrationsRows.map((row) => row.name));
 
         for (const migration of migrations) {
           if (!appliedMigrations.has(migration.name)) {
             await connection.query(migration.up);
-            await connection.query(`INSERT INTO ${TABLE_MIGRATIONS} (name) VALUES (?)`, [migration.name]);
+            await connection.query(`INSERT INTO ${migrationsTable()} (name) VALUES (?)`, [migration.name]);
             logger.debug(`Applied up migration ${migration.name}`);
           }
         }
@@ -207,11 +207,21 @@ export function Database(logger: Logger, options: { uri: string }) {
     async updateQueue(params: DbUpdateQueueParams) {
       await withConnection((connection) => {
         return connection.query(
-          `UPDATE ${TABLE_QUEUES} SET maxRetries = ?, minDelayMs = ?, backoffMultiplier = ?, maxDurationMs = ? WHERE id = ?`,
+          `UPDATE ${queuesTable()} SET maxRetries = ?, minDelayMs = ?, backoffMultiplier = ?, maxDurationMs = ? WHERE id = ?`,
           [params.maxRetries, params.minDelayMs, params.backoffMultiplier, params.maxDurationMs, params.id],
         );
       });
     },
     withConnection,
   };
+
+  function migrationsTable() {
+    return TABLES_NAME_PREFIX + (options.tablesPrefix || "") + "migrations";
+  }
+  function queuesTable() {
+    return TABLES_NAME_PREFIX + (options.tablesPrefix || "") + "queues";
+  }
+  function jobsTable() {
+    return TABLES_NAME_PREFIX + (options.tablesPrefix || "") + "jobs";
+  }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,6 +5,7 @@ export interface Options {
   dbUri: string;
   loggingLevel?: LevelWithSilentOrString;
   loggingPrettyPrint?: boolean;
+  tablesPrefix?: string;
 }
 
 export interface Queue {

--- a/packages/core/tests/performance.test.ts
+++ b/packages/core/tests/performance.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
 import { MysqlQueue } from "../src";
+import { randomUUID } from "node:crypto";
 import { waitInvoked } from "./utils/waitInvoked";
 
 describe("Performance", () => {
@@ -11,6 +12,7 @@ describe("Performance", () => {
   };
   const mysqlQueue = MysqlQueue({
     dbUri: "mysql://root:password@localhost:3306/serenis",
+    tablesPrefix: `${randomUUID().slice(-4)}_`,
   });
 
   afterEach(async () => {


### PR DESCRIPTION
This PR adds the `tablesPrefix` option. If this parameter is provided, the 3 tables will include the specified prefix (for example, setting the prefix to `PREFIX_` will result in the _jobs_ table being named `mysql_queue_PREFIX_jobs`).  
This allows multiple instances of mysql-queue to coexist within the same database without interfering with each other.  

The specific use case is for E2E tests of the same application, where each test suite runs the full app. Since the tests run in parallel, jobs from one suite were being consumed by another, and vice versa.