### PR TITLE
get promise for job execution

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export function MysqlQueue(options: Options) {
 
       return `INSERT INTO ${database.jobsTable()} (id, name, payload, status, priority, startAfter, queueId) SELECT j.id, j.name, j.payload, j.status, j.priority, j.startAfter, q.id FROM (${values}) AS j(id, name, payload, status, priority, startAfter) JOIN ${database.queuesTable()} q ON q.name = '${queueName}'`;
     },
+    getJobExecutionPromise: workersFactory.getJobExecutionPromise,
     async initialize() {
       logger.debug("starting");
       await database.runMigrations();


### PR DESCRIPTION
This PR adds the `getJobExecutionPromise` method. It allows you to obtain a promise that resolves when a job is processed. This should not be used in production, but it is very convenient within tests to "wait" for a job to be processed.


Example 
```typescript
const promise = instance.getJobExecutionPromise(queueName);
const workerCbMock = vi.fn();
const worker = await instance.work(queueName, workerCbMock);
const { jobIds } = await instance.enqueue(queueName, {name: "test_job", payload: { message: "Hello, world!" }});
void worker.start();

await promise;

expect(workerCbMock).toHaveBeenCalledWith(expect.objectContaining({ id: jobIds[0] }), expect.anything(), expect.anything());
```