### PR TITLE
fix(core): db use utc dates

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -7,7 +7,7 @@ const TABLES_NAME_PREFIX = "mysql_queue_";
 export type Database = ReturnType<typeof Database>;
 
 export function Database(logger: Logger, options: { uri: string; tablesPrefix?: string }) {
-  const pool = createPool({ uri: options.uri, waitForConnections: true });
+  const pool = createPool({ timezone: "Z", uri: options.uri, waitForConnections: true });
 
   const migrations = [
     {


### PR DESCRIPTION
This PR adds the parameter to `mysql2` to use UTC dates, because — incredibly — the default is to use the *local* timezone.
