### PR TITLE
Introduce external db callback on enqueue method

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,4 @@
-import { EnqueueParams, JobForInsert, Options, Queue, RetrieveQueueParams, UpsertQueueParams, WorkerCallback } from "./types";
-import { Connection } from "mysql2/promise";
+import { EnqueueParams, JobForInsert, Options, Queue, RetrieveQueueParams, Session, UpsertQueueParams, WorkerCallback } from "./types";
 import { Database } from "./database";
 import { Logger } from "./logger";
 import { randomUUID } from "node:crypto";
@@ -37,7 +36,7 @@ export function MysqlQueue(options: Options) {
       logger.flush();
     },
 
-    async enqueue(queueName: string, params: EnqueueParams, connection?: Connection) {
+    async enqueue(queueName: string, params: EnqueueParams, session?: Session) {
       const jobsForInsert: JobForInsert[] = (Array.isArray(params) ? params : [params]).map((p) => ({
         id: randomUUID(),
         name: p.name,
@@ -47,7 +46,7 @@ export function MysqlQueue(options: Options) {
         status: "pending",
       }));
 
-      await database.addJobs(queueName, jobsForInsert, connection);
+      await database.addJobs(queueName, jobsForInsert, session);
       logger.info({ jobs: jobsForInsert }, "jobsAddedToQueue");
       return { jobIds: jobsForInsert.map((j) => j.id) };
     },

--- a/packages/core/src/jobProcessor.ts
+++ b/packages/core/src/jobProcessor.ts
@@ -5,7 +5,7 @@ import { PoolConnection } from "mysql2/promise";
 
 export function JobProcessor(database: Database, logger: Logger, queue: Queue, callback: WorkerCallback) {
   async function process(job: Job, workerAbortSignal: AbortSignal) {
-    await database.withConnection(async (connection) => {
+    await database.runWithPoolConnection(async (connection) => {
       await connection.beginTransaction();
       try {
         try {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,3 +65,7 @@ export type EnqueueParams = AddParams | AddParams[];
 export type DbCreateQueueParams = Queue;
 export type DbUpdateQueueParams = Queue;
 export type DbAddJobsParams = JobForInsert;
+
+export type Session = {
+  query: (sql: string, parameters: unknown[]) => Promise<[{ affectedRows: number }]>;
+};


### PR DESCRIPTION
With this PR, it is possible to pass an object called _session_ to the `enqueue` method, like this.
```typescript
await instance.enqueue(queue, job, session)
```

The idea is to have a callback that allows executing the sql code computed by the library during `enqueue`.
This makes it possible to perform `enqueue` using connections other than the one from `mysql2` (used internally by the library).

```typescript
export type Session = {
  query: (sql: string, parameters: unknown[]) => Promise<[{ affectedRows: number }]>;
};
```


For example, with Kysely, to perform an enqueue within a transaction, you can use it like this
```typescript
await kysely.transaction().execute(async (trx) => {
    await instance.enqueue(queueName, job, adaptKyselyTrx(trx))
})


function adaptKyselyTrx(trx) => ({ query: (query: string, values?: unknown[]) => trx.executeQuery(sql.raw(query, values)) })
```


closes #21 