### PR TITLE
fix getEnqueueRawSql with empty array as param

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export function MysqlQueue(options: Options) {
         startAfter: p.startAfter || null,
         status: "pending",
       }));
+      if (jobsForInsert.length === 0) return "SELECT NULL LIMIT 0;";
 
       const values = jobsForInsert
         .map(

--- a/packages/core/tests/mysqlQueue.test.ts
+++ b/packages/core/tests/mysqlQueue.test.ts
@@ -161,6 +161,12 @@ describe("mysqlQueue", () => {
       ).rejects.toThrowError("Failed to add jobs, maybe queue does not exist");
     });
 
+    it("should not throw case 0 jobs params passed", async () => {
+      await instance.enqueue(queueName, []);
+      const sql = instance.getEnqueueRawSql(queueName, []);
+      expect(sql).toEqual("SELECT NULL LIMIT 0;");
+    });
+
     it("should fire the worker callback", async () => {
       const promise = instance.getJobExecutionPromise(queueName);
 


### PR DESCRIPTION
This pr fixes the `getEnqueueRawSql` method used like `mysqlQueue.getEnqueueRawSql(queueName, [])`.
Before this, the returned SQL was invalid.

The behavior now is the same as the `enqueue` method. If an empty array is passed, the method returns silently