### PR TITLE
Add payload max size check

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,7 @@ export interface Options {
   dbUri: string;
   loggingLevel?: LevelWithSilentOrString;
   loggingPrettyPrint?: boolean;
+  maxPayloadSizeKb?: number;
   tablesPrefix?: string;
 }
 

--- a/packages/core/tests/mysqlQueue.test.ts
+++ b/packages/core/tests/mysqlQueue.test.ts
@@ -233,6 +233,12 @@ describe("mysqlQueue", () => {
         await worker.stop();
         expect(workerCbMock).toHaveBeenCalledTimes(2);
       });
+
+      it("should throw case payload size exceed limit", async () => {
+        await expect(() =>
+          instance.enqueue(queueName, [{ name: "test_job", payload: { data: "a".repeat(1024 * 1024) } }]),
+        ).rejects.toThrowError("Payload size exceeds maximum allowed size");
+      });
     });
 
     describe("with session", () => {


### PR DESCRIPTION
This pr introduces payload size checking during enqueue. The default limit is 16K, but it’s customizable.

close #28