### PR TITLE
Replace mysql connection with session in worker callback

### DIFF
--- a/packages/core/src/jobProcessor.ts
+++ b/packages/core/src/jobProcessor.ts
@@ -1,5 +1,5 @@
 import { errorToJson, truncateStr } from "./utils";
-import { Job, Queue, WorkerCallback } from "./types";
+import { Job, Queue, Session, WorkerCallback } from "./types";
 import { Database } from "./database";
 import { Logger } from "./logger";
 import { PoolConnection } from "mysql2/promise";
@@ -63,7 +63,7 @@ export function JobProcessor(database: Database, logger: Logger, queue: Queue, c
     }
     workerAbortSignal.addEventListener("abort", onWorkerAbort);
 
-    const callbackPromise = callback(job, callbackAbortController.signal, connection);
+    const callbackPromise = callback(job, callbackAbortController.signal, connection as unknown as Session);
     const timeoutPromise = new Promise((_, reject) => {
       timeoutId = setTimeout(() => {
         callbackAbortController.abort();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,3 @@
-import { Connection } from "mysql2/promise";
 import { LevelWithSilentOrString } from "pino";
 
 export interface Options {
@@ -40,7 +39,7 @@ export interface JobForInsert {
   startAfter: Date | null;
 }
 
-export type WorkerCallback = (job: Job, signal: AbortSignal, connection: Connection) => Promise<void> | void;
+export type WorkerCallback = (job: Job, signal: AbortSignal, session: Session) => Promise<void> | void;
 
 export interface UpsertQueueParams {
   maxRetries?: number;


### PR DESCRIPTION
This pr ensures that the session (the same one used for enqueueing) is passed into the worker’s callback instead of the MySQL connection.

The type isn’t 100% accurate yet, but it’s a starting point.

