### PR TITLE
Better locks usage

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,8 @@ export interface Job {
   startAfter: Date | null;
 }
 
+export type JobWithQueueName = Job & { queueName: string };
+
 export interface JobForInsert {
   id: string;
   name: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,7 +36,7 @@ export interface JobForInsert {
   payload: unknown;
   status: "pending";
   priority: number;
-  startAfter: Date | null;
+  startAfter: Date;
 }
 
 export type WorkerCallback = (job: Job, signal: AbortSignal, session: Session) => Promise<void> | void;
@@ -63,7 +63,7 @@ export type EnqueueParams = AddParams | AddParams[];
 
 export type DbCreateQueueParams = Queue;
 export type DbUpdateQueueParams = Queue;
-export type DbAddJobsParams = JobForInsert;
+export type DbAddJobsParams = JobForInsert[];
 
 export type Session = {
   query: (sql: string, parameters: unknown[]) => Promise<[{ affectedRows: number }]>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,7 @@ export interface Queue {
   name: string;
   maxRetries: number;
   minDelayMs: number;
-  backoffMultiplier: number | null;
+  backoffMultiplier: number;
   maxDurationMs: number;
 }
 
@@ -27,7 +27,7 @@ export interface Job {
   attempts: number;
   latestFailureReason: string | null;
   queueId: string;
-  startAfter: Date | null;
+  startAfter: Date;
 }
 
 export type JobWithQueueName = Job & { queueName: string };
@@ -39,6 +39,7 @@ export interface JobForInsert {
   status: "pending";
   priority: number;
   startAfter: Date;
+  createdAt: Date;
 }
 
 export type WorkerCallback = (job: Job, signal: AbortSignal, session: Session) => Promise<void> | void;

--- a/packages/core/tests/mysqlQueue.test.ts
+++ b/packages/core/tests/mysqlQueue.test.ts
@@ -31,21 +31,6 @@ describe("mysqlQueue", () => {
           id: 2,
           name: "create-jobs-table",
         },
-        {
-          applied_at: expect.any(Date),
-          id: 3,
-          name: "add-id-to-index",
-        },
-        {
-          applied_at: expect.any(Date),
-          id: 4,
-          name: "not-nullable-start-after",
-        },
-        {
-          applied_at: expect.any(Date),
-          id: 5,
-          name: "jobs-ms-timestamp",
-        },
       ]);
     });
 
@@ -127,6 +112,36 @@ describe("mysqlQueue", () => {
         name: "test_quque",
       });
     });
+
+    it("should set backoffMultiplier to 2 if 0 is passed", async () => {
+      const queueName = "test_quque";
+      await instance.upsertQueue(queueName, { backoffMultiplier: 0 });
+
+      const [row] = await queryDatabase.query<RowDataPacket[]>(`SELECT * FROM ${instance.queuesTable()};`);
+
+      expect(isValidUUID(row.id)).toBeTruthy();
+      expect(row.backoffMultiplier).toEqual(2);
+    });
+
+    it("should set backoffMultiplier to 2 if -1 is passed", async () => {
+      const queueName = "test_quque";
+      await instance.upsertQueue(queueName, { backoffMultiplier: -1 });
+
+      const [row] = await queryDatabase.query<RowDataPacket[]>(`SELECT * FROM ${instance.queuesTable()};`);
+
+      expect(isValidUUID(row.id)).toBeTruthy();
+      expect(row.backoffMultiplier).toEqual(2);
+    });
+
+    it("should set backoffMultiplier to 3 if 3 is passed", async () => {
+      const queueName = "test_quque";
+      await instance.upsertQueue(queueName, { backoffMultiplier: 3 });
+
+      const [row] = await queryDatabase.query<RowDataPacket[]>(`SELECT * FROM ${instance.queuesTable()};`);
+
+      expect(isValidUUID(row.id)).toBeTruthy();
+      expect(row.backoffMultiplier).toEqual(3);
+    });
   });
 
   describe("enqueue", () => {
@@ -165,6 +180,7 @@ describe("mysqlQueue", () => {
           startAfter: expect.any(Date),
           status: "pending",
         });
+        expect(row.startAfter.getTime()).toBe(row.createdAt.getTime());
       });
 
       it("should throw case queue not exists", async () => {

--- a/packages/core/tests/mysqlQueue.test.ts
+++ b/packages/core/tests/mysqlQueue.test.ts
@@ -31,6 +31,21 @@ describe("mysqlQueue", () => {
           id: 2,
           name: "create-jobs-table",
         },
+        {
+          applied_at: expect.any(Date),
+          id: 3,
+          name: "add-id-to-index",
+        },
+        {
+          applied_at: expect.any(Date),
+          id: 4,
+          name: "not-nullable-start-after",
+        },
+        {
+          applied_at: expect.any(Date),
+          id: 5,
+          name: "jobs-ms-timestamp",
+        },
       ]);
     });
 
@@ -147,7 +162,7 @@ describe("mysqlQueue", () => {
           payload: { message: "Hello, world!" },
           priority: 0,
           queueId: expect.any(String),
-          startAfter: null,
+          startAfter: expect.any(Date),
           status: "pending",
         });
       });
@@ -165,8 +180,6 @@ describe("mysqlQueue", () => {
 
       it("should not throw case 0 jobs params passed", async () => {
         await instance.enqueue(queueName, []);
-        const sql = instance.getEnqueueRawSql(queueName, []);
-        expect(sql).toEqual("SELECT NULL LIMIT 0;");
       });
 
       it("should fire the worker callback", async () => {
@@ -241,7 +254,7 @@ describe("mysqlQueue", () => {
           payload: { message: "Hello, world!" },
           priority: 0,
           queueId: expect.any(String),
-          startAfter: null,
+          startAfter: expect.any(Date),
           status: "pending",
         });
       });

--- a/packages/core/tests/performance.test.ts
+++ b/packages/core/tests/performance.test.ts
@@ -12,6 +12,7 @@ describe("Performance", () => {
   };
   const mysqlQueue = MysqlQueue({
     dbUri: "mysql://root:password@localhost:3306/serenis",
+    loggingLevel: "fatal",
     tablesPrefix: `${randomUUID().slice(-4)}_`,
   });
 

--- a/packages/core/tests/workers.test.ts
+++ b/packages/core/tests/workers.test.ts
@@ -108,7 +108,7 @@ describe("workers", () => {
 
       const expected = [0, 1032, 3064, 7135];
       callsToTimeFromFirst(calls).forEach((ms, i) => {
-        expect(approxEqual(ms, expected[i], 100)).toBeTruthy();
+        expect(approxEqual(ms, expected[i], 200)).toBeTruthy();
       });
     }, 10_000);
 

--- a/packages/core/tests/workers.test.ts
+++ b/packages/core/tests/workers.test.ts
@@ -14,6 +14,7 @@ describe("workers", () => {
   beforeEach(async () => {
     mysqlQueue = MysqlQueue({
       dbUri: DB_URI,
+      loggingLevel: "fatal",
       tablesPrefix: `${randomUUID().slice(-4)}_`,
     });
     await mysqlQueue.initialize();
@@ -102,12 +103,5 @@ function enqueueNJobs(mysqlQueue: MysqlQueue, queueName: string, n: number) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function hasExactly(arr: any[], count: number, predicate: (item: any) => boolean) {
-  let matchCount = 0;
-  for (const item of arr) {
-    if (predicate(item)) {
-      matchCount++;
-      if (matchCount > count) return false;
-    }
-  }
-  return matchCount === count;
+  return arr.filter(predicate).length === count;
 }

--- a/packages/core/tests/workers.test.ts
+++ b/packages/core/tests/workers.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vitest } from "vitest";
+import { createPool, RowDataPacket } from "mysql2/promise";
+import { MysqlQueue } from "../src";
+import { randomUUID } from "node:crypto";
+
+const DB_URI = "mysql://root:password@localhost:3306/serenis";
+
+describe("workers", () => {
+  const pool = createPool(DB_URI);
+  const queueName = "test_queue";
+
+  let mysqlQueue: MysqlQueue;
+
+  beforeEach(async () => {
+    mysqlQueue = MysqlQueue({
+      dbUri: DB_URI,
+      tablesPrefix: `${randomUUID().slice(-4)}_`,
+    });
+    await mysqlQueue.initialize();
+    await mysqlQueue.upsertQueue(queueName, { maxDurationMs: 10_000 });
+  });
+
+  afterEach(async () => {
+    await mysqlQueue.destroy();
+    await mysqlQueue.dispose();
+  });
+
+  describe("two worker with different handler latency", () => {
+    const Worker1HandlerMock = { handle: vitest.fn().mockImplementation(async () => await sleep(3000)) };
+    const Worker2HandlerMock = { handle: vitest.fn() };
+    let worker1: Awaited<ReturnType<typeof mysqlQueue.work>>;
+    let worker2: Awaited<ReturnType<typeof mysqlQueue.work>>;
+
+    beforeEach(async () => {
+      worker1 = await mysqlQueue.work(queueName, Worker1HandlerMock.handle, undefined, 5);
+      worker2 = await mysqlQueue.work(queueName, Worker2HandlerMock.handle, undefined, 5);
+    });
+
+    afterEach(async () => {
+      await Promise.all([worker1.stop(), worker2.stop()]);
+    });
+
+    it("should distribute jobs between two workers without any job being processed more than once", async () => {
+      const promise = mysqlQueue.getJobExecutionPromise(queueName, 10);
+      await enqueueNJobs(mysqlQueue, queueName, 10);
+
+      void Promise.all([worker1.start(), worker2.start()]);
+      await promise;
+
+      const w1JobIds = Worker1HandlerMock.handle.mock.calls.map((c) => c[0].id);
+      const w2JobIds = Worker2HandlerMock.handle.mock.calls.map((c) => c[0].id);
+      expect(haveNoCommonElements(w1JobIds, w2JobIds)).toBeTruthy();
+      expect(Worker1HandlerMock.handle).toHaveBeenCalledTimes(5);
+      expect(Worker2HandlerMock.handle).toHaveBeenCalledTimes(5);
+    });
+
+    it("should ensure that a slow worker does not block or delay other workers, case jobs already on queue", async () => {
+      await enqueueNJobs(mysqlQueue, queueName, 10);
+      void Promise.all([worker1.start(), worker2.start()]);
+      const promise = mysqlQueue.getJobExecutionPromise(queueName, 10);
+
+      await promise;
+
+      await sleep(500);
+      const [rows] = await pool.query<RowDataPacket[]>(`SELECT id, createdAt, completedAt from ${mysqlQueue.jobsTable()}`);
+      const jobs = rows.map((j) => ({ ...j, durationMs: new Date(j.completedAt).getTime() - new Date(j.createdAt).getTime() }));
+      expect(hasExactly(jobs, 5, (item) => item.durationMs > 3000)).toBeTruthy();
+      expect(hasExactly(jobs, 5, (item) => item.durationMs < 100)).toBeTruthy();
+    });
+
+    it("should ensure that a slow worker does not block or delay other workers, case no jobs on queue", async () => {
+      void Promise.all([worker1.start(), worker2.start()]);
+      await enqueueNJobs(mysqlQueue, queueName, 10);
+      const promise = mysqlQueue.getJobExecutionPromise(queueName, 10);
+
+      await promise;
+
+      await sleep(500);
+      const [rows] = await pool.query<RowDataPacket[]>(`SELECT id, createdAt, completedAt from ${mysqlQueue.jobsTable()}`);
+      const jobs = rows.map((j) => ({ ...j, durationMs: new Date(j.completedAt).getTime() - new Date(j.createdAt).getTime() }));
+      expect(hasExactly(jobs, 5, (item) => item.durationMs > 3000)).toBeTruthy();
+      expect(hasExactly(jobs, 5, (item) => item.durationMs < 1000)).toBeTruthy();
+    });
+  });
+});
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function haveNoCommonElements(arr1: unknown[], arr2: unknown[]) {
+  const set1 = new Set(arr1);
+  return arr2.every((item) => !set1.has(item));
+}
+
+function enqueueNJobs(mysqlQueue: MysqlQueue, queueName: string, n: number) {
+  return mysqlQueue.enqueue(
+    queueName,
+    Array.from({ length: n }).map((_, index) => ({ name: `job-${index}`, payload: {}, startAfter: new Date(Date.now() - 10_000) })),
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasExactly(arr: any[], count: number, predicate: (item: any) => boolean) {
+  let matchCount = 0;
+  for (const item of arr) {
+    if (predicate(item)) {
+      matchCount++;
+      if (matchCount > count) return false;
+    }
+  }
+  return matchCount === count;
+}


### PR DESCRIPTION
This pr was born with the idea to add a test suite dedicated to the workers' pov. Doing this, I realized some unexpected behaviours that led me to make some changes. It’s a bit strange, but it’s a new project and I expected it to happen.

- Add a better index called `idx_queueId_status_createdAt_priority_createdAt_id`. This should be the correct index that allows both good performance and the expected behavior from _FOR UPDATE SKIP LOCKED_.
- Convert `startAt` to a non-nullable column on the _jobs_ table. getPendingJobs used an _or_, which made it harder for the index to be used effectively.
- Edit timestamps precision to milliseconds on the _jobs_ table.
- Add forced index usage in the `getPendingJobs` query. It's not commonly seen in production, but it's the only way I found to achieve behavior that doesn't depend on circumstances (for example, whether the table has 0 rows or many rows at the time a worker starts).
- Fix the order of migration application during destroy, applying them from the last to the first.
- Add elapsedSeconds field to `jobProcessor.processBatch.committed` log entry.
- Set transaction level for job processor to `READ COMMITTED`. In general, it is better suited for the purpose and maximizes the likelihood that the transaction finds rows to process.
- Add new shininig _workers_ test suite.
