### PR TITLE
First real release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@serenis-health/mysql-queue-monorepo",
-  "version": "0.0.1",
+  "name": "@serenis/mysql-queue-monorepo",
+  "version": "0.0.2",
   "packageManager": "pnpm@9.15.0",
   "scripts": {
     "lint": "eslint --fix . && prettier --write .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "@serenis-health/mysql-queue",
-  "version": "0.0.0",
+  "name": "@serenis/mysql-queue",
+  "version": "0.0.2",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
     "@types/node": "^22.13.15",
@@ -15,6 +16,9 @@
     "mysql2": "^3.14.0",
     "pino": "^9.6.0"
   },
-  "main": "dist/index",
-  "types": "dist/index.d.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,3 +99,5 @@ export function MysqlQueue(options: Options) {
 }
 
 export type MysqlQueue = ReturnType<typeof MysqlQueue>;
+
+export { Session } from "./types";


### PR DESCRIPTION
Thanks to this pr, anyone in the world can use _mysql-queue_ by installing it with `npm install @serenis/mysql-queue`.
