### PR TITLE
Export job from types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,4 +100,4 @@ export function MysqlQueue(options: Options) {
 
 export type MysqlQueue = ReturnType<typeof MysqlQueue>;
 
-export { Session } from "./types";
+export { Session, Job } from "./types";


### PR DESCRIPTION
To avoid `import { Job } from '@serenis/mysql-queue/dist/types'`