### PR TITLE
Add on job failed callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenis/mysql-queue-monorepo",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "packageManager": "pnpm@9.15.0",
   "scripts": {
     "lint": "eslint --fix . && prettier --write .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serenis/mysql-queue",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -87,10 +87,8 @@ export function Database(logger: Logger, options: { uri: string; tablesPrefix?: 
     async endPool() {
       await pool.end();
     },
-    async getJobById(jobId: string) {
-      const [rows] = await runWithPoolConnection((connection) =>
-        connection.query<RowDataPacket[]>(`SELECT * FROM ${jobsTable()} WHERE id = ?`, [jobId]),
-      );
+    async getJobById(connection: PoolConnection, jobId: string) {
+      const [rows] = await connection.query<RowDataPacket[]>(`SELECT * FROM ${jobsTable()} WHERE id = ?`, [jobId]);
       return rows.length ? rows[0] : null;
     },
     async getPendingJobs(connection: PoolConnection, queueId: string, batchSize: number) {


### PR DESCRIPTION
This PR introduces a new `onJobFailed` hook at the worker level.
The hook is triggered only when a job has exhausted all retry attempts and ultimately fails.

## Motivation
- Provides a clear and consistent way to be notified when a job cannot be completed successfully after all retries
- Enables custom handling of terminal job failures (e.g., logging, alerts, cleanup)

## Usage
```typescript
const worker = await mysqlQueue.work(queue, handler, (job, error) => {
    Sentry.captureException(error, scope => {
      scope.setExtra("job", job;
      return scope;
    });
  }
);
```