### PR TITLE
fix: remove db query from job failed callback

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,14 +1,4 @@
-import {
-  EnqueueParams,
-  JobForInsert,
-  JobWithQueueName,
-  Options,
-  Queue,
-  RetrieveQueueParams,
-  Session,
-  UpsertQueueParams,
-  WorkerCallback,
-} from "./types";
+import { EnqueueParams, JobForInsert, Options, Queue, RetrieveQueueParams, Session, UpsertQueueParams, WorkerCallback } from "./types";
 import { Database } from "./database";
 import { Logger } from "./logger";
 import { randomUUID } from "node:crypto";
@@ -105,7 +95,7 @@ export function MysqlQueue(options: Options) {
       callback: WorkerCallback,
       pollingIntervalMs = 500,
       batchSize = 1,
-      onJobFailed?: (job: JobWithQueueName, error: Error) => void,
+      onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void,
     ) {
       const queue = await retrieveQueue({ name: queueName });
       return workersFactory.create(callback, pollingIntervalMs, batchSize, queue, onJobFailed);

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -15,7 +15,7 @@ export function WorkersFactory(logger: Logger, database: Database) {
       pollingIntervalMs = 500,
       batchSize = 1,
       queue: Queue,
-      onJobFailed?: (job: JobWithQueueName, error: Error) => void,
+      onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void,
     ) {
       const worker = Worker(
         callback,
@@ -64,7 +64,7 @@ export function Worker(
   database: Database,
   queue: Queue,
   onJobProcessed?: (job: JobWithQueueName) => void,
-  onJobFailed?: (job: JobWithQueueName, error: Error) => void,
+  onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void,
 ) {
   const workerId = randomUUID();
   const wLogger = logger.child({ workerId });

--- a/packages/core/tests/workers.test.ts
+++ b/packages/core/tests/workers.test.ts
@@ -187,21 +187,13 @@ describe("workers", () => {
       void worker.start();
 
       const promise = mysqlQueue.getJobExecutionPromise(queueName, maxRetries);
-      mysqlQueue.enqueue(queueName, { name: "1", payload: {} });
+      const {
+        jobIds: [jobId],
+      } = await mysqlQueue.enqueue(queueName, { name: "1", payload: {} });
       await promise;
 
       expect(OnJobFailedMock).toHaveBeenCalledTimes(1);
-      expect(OnJobFailedMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          attempts: 3,
-          completedAt: null,
-          failedAt: expect.any(Date),
-          latestFailureReason: "Unexpected",
-          queueName: "test_queue",
-          status: "failed",
-        }),
-        error,
-      );
+      expect(OnJobFailedMock).toHaveBeenCalledWith(error, { id: jobId, queueName });
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR removes the database query from the "job failed" callback handler. The goal is to prevent timeout errors and other failures when the database connection is unavailable or an exception is thrown.

## Why
- Ensure that the `onJobFailed` callback is always triggered, regardless of database availability or prior failures
- Prevent jobs from staying stuck in `pending` state due to errors that block the database transaction from committing