### PR TITLE
wip

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": ["Bash(docker exec:*)", "Bash(docker-compose:*)", "Bash(npm run build:*)", "Bash(node:*)", "Bash(npm test:*)"],
-    "deny": [],
-    "ask": []
-  }
-}


### PR DESCRIPTION
## **Before: The Race Condition Problem**

When a job handler exceeded the timeout:
1. **AbortSignal sent** to worker callback
2. **Job marked as failed/retried** in database  
3. **Slow SQL query kept running** in background
4. **Query could complete AFTER timeout** - causing data inconsistency
5. **No way to actually stop** the running MySQL query

**Result**: Jobs showed as "failed" but their work actually succeeded, leading to duplicate processing and data corruption.

## **After: The Connection Destruction Solution**

When a job handler exceeds timeout:
1. **AbortSignal sent** to worker callback
2. **Connection immediately destroyed** (`connection.destroy()`)
3. **MySQL query physically killed** on server side
4. **Job status updated via fresh connection** (fallback mechanism)
5. **Row locks released** when connection dies
6. **Graceful error handling** for closed connection states

**Result**: True cancellation - slow queries cannot complete after timeout, eliminating race conditions while maintaining proper job state tracking.

## **Key Technical Changes**

- **Added `connection.destroy()`** in timeout handler to kill slow queries
- **Implemented `executeWithFallback()`** in database methods to handle destroyed connections
- **Added `tryCommit()` and `tryRollback()`** functions to gracefully handle transaction failures
- **Created `isConnectionClosed()`** utility to detect specific connection errors
- **Maintained ACID properties** where possible while providing fallback for unavoidable connection losses

## **Drawbacks and Trade-offs**

- **Connection Pool Impact**: Destroyed connections cannot be reused, requiring new connections from the pool
- **Transaction Atomicity Loss**: Job execution and status updates are no longer in the same transaction
- **Increased Complexity**: Fallback mechanisms add code complexity and multiple error paths
- **Resource Usage**: Timeout scenarios now consume 2x connections (original + fallback)
- **Lock Release Delay**: Row locks may remain held for 30-60 seconds after connection destruction
- **Monitoring Overhead**: Additional logging and error handling increases observability complexity

**Trade-off Decision**: We chose correctness over perfect resource efficiency - eliminating race conditions is more critical than optimizing connection usage during timeout scenarios.

The solution ensures that **timeouts actually timeout** - no more phantom work completing after jobs are marked as failed.