### PR TITLE
Add idempotence and pending deduplication support

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,5 +2,5 @@
   "ignorePaths": ["dist", "node_modules", "**/*.d.ts"],
   "version": "0.2",
   "language": "en",
-  "words": ["serenis"]
+  "words": ["serenis", "dedup"]
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,17 +36,19 @@ export function MysqlQueue(_options: Options) {
         return {
           createdAt: now,
           id: randomUUID(),
+          idempotentKey: p.idempotentKey,
           name: p.name,
           payload: payloadStr,
+          pendingDedupKey: p.pendingDedupKey,
           priority: p.priority || 0,
           startAfter: p.startAfter || now,
           status: "pending",
         };
       });
 
-      await database.addJobs(queueName, jobsForInsert, options.partitionKey, session);
-      logger.debug({ jobs: jobsForInsert }, "enqueue.jobsAddedToQueue");
-      logger.info({ jobCount: jobsForInsert.length }, "enqueue.jobsAddedToQueue");
+      const affectedRows = await database.addJobs(queueName, jobsForInsert, options.partitionKey, session);
+      logger.debug({ jobCount: affectedRows, jobs: jobsForInsert }, "enqueue.jobsAddedToQueue");
+      logger.info({ jobCount: affectedRows }, "enqueue.jobsAddedToQueue");
       return { jobIds: jobsForInsert.map((j) => j.id) };
     },
     getJobExecutionPromise: workersFactory.getJobExecutionPromise,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,6 +43,8 @@ export interface JobForInsert {
   priority: number;
   startAfter: Date;
   createdAt: Date;
+  idempotentKey?: string;
+  pendingDedupKey?: string;
 }
 
 export type WorkerCallback = (job: Job, signal: AbortSignal, session: Session) => Promise<void> | void;
@@ -63,6 +65,8 @@ export interface AddParams {
   payload: unknown;
   priority?: number;
   startAfter?: Date;
+  idempotentKey?: string;
+  pendingDedupKey?: string;
 }
 
 export type EnqueueParams = AddParams | AddParams[];

--- a/packages/core/tests/utils/queryDatabase.ts
+++ b/packages/core/tests/utils/queryDatabase.ts
@@ -13,10 +13,10 @@ export function QueryDatabase(params: { dbUri: string }) {
       await pool.end();
     },
     pool,
-    async query<T extends QueryResult>(sql: string) {
+    async query<T extends QueryResult>(sql: string, parameters?: unknown[]) {
       const connection = await pool.getConnection();
       try {
-        const [rows] = await connection.query<T>(sql);
+        const [rows] = await connection.query<T>(sql, parameters);
         return rows;
       } finally {
         connection.release();


### PR DESCRIPTION
Add idempotence and pending deduplication features.

Changes:
- Added `idempotentKey` enqueue param to prevent duplicate jobs with the same key and name across all statuses
- Added `pendingDedupKey` enqueue param to prevent duplicate pending jobs, allowing re-enqueuing after completion/failure

Use cases
- idempotentKey: ideal for tasks that must never run more than once, e.g. sending a notification, provisioning resources, or any irreversible/costly operation.
- pendingDeduplicationKey: ideal for tasks that should not be queued multiple times concurrently, e.g. cache refreshes, retryable jobs, or batch processing that should run again after the current one completes.


