### PR TITLE
fix(core): session execute use mysql connection query method

### DIFF
--- a/packages/core/src/jobProcessor.ts
+++ b/packages/core/src/jobProcessor.ts
@@ -144,7 +144,7 @@ export function JobProcessor(
 function createSessionWrapper(connection: PoolConnection): Session {
   return {
     execute: async (sql: string, parameters: unknown[]) => {
-      const [result] = await connection.execute(sql, parameters);
+      const [result] = await connection.query(sql, parameters);
       return [result as { affectedRows: number }];
     },
     query: async <TRow = unknown>(sql: string, parameters: unknown[]) => {


### PR DESCRIPTION

In `mysql2`, `query()` and `execute()` are both used to run SQL queries, but they have key differences.

* **`query()`** is flexible: it can run any SQL, is suitable for dynamic queries, and automatically converts `undefined` parameters to `NULL`.
* **`execute()`** is safer and more efficient for repeated queries because it prepares the statement. However, it **does not accept `undefined`**; you must use `null` explicitly.


For now, both _query_ and _execute_ Session methods use _query_ mysql2 connection method.
