### PR TITLE
feat(core): pause queue

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,11 @@ export function MysqlQueue(_options: Options) {
     },
     jobsTable: database.jobsTable,
     migrationTable: database.migrationsTable,
+    async pauseQueue(queueName: string) {
+      logger.debug({ partitionKey: options.partitionKey, queueName }, "pausingQueue");
+      await database.pauseQueue(queueName, options.partitionKey);
+      logger.info({ partitionKey: options.partitionKey, queueName }, "queuePaused");
+    },
     async purge() {
       logger.debug({ partitionKey: options.partitionKey }, "purging");
 
@@ -72,6 +77,11 @@ export function MysqlQueue(_options: Options) {
       logger.info({ partitionKey: options.partitionKey }, "purged");
     },
     queuesTable: database.queuesTable,
+    async resumeQueue(queueName: string) {
+      logger.debug({ partitionKey: options.partitionKey, queueName }, "resumingQueue");
+      await database.resumeQueue(queueName, options.partitionKey);
+      logger.info({ partitionKey: options.partitionKey, queueName }, "queueResumed");
+    },
     retrieveQueue,
     async upsertQueue(name: string, params: UpsertQueueParams = {}) {
       const queueWithoutId: Omit<Queue, "id"> = {
@@ -81,6 +91,7 @@ export function MysqlQueue(_options: Options) {
         minDelayMs: params.minDelayMs || 1000,
         name,
         partitionKey: options.partitionKey,
+        paused: false,
       };
 
       let id: string;

--- a/packages/core/src/jobProcessor.ts
+++ b/packages/core/src/jobProcessor.ts
@@ -34,6 +34,8 @@ export function JobProcessor(
 
       try {
         if (workerAbortSignal.aborted) return;
+        if (await database.isQueuePaused(queue.id)) return;
+
         await database.runWithPoolConnection(async (connection) => {
           const transactionId = randomUUID();
           const start = Date.now();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,7 @@ export interface Queue {
   backoffMultiplier: number;
   maxDurationMs: number;
   partitionKey: string;
+  paused: boolean;
 }
 
 export interface Job {


### PR DESCRIPTION
This pr introduces a simple way to pause (and resume) a specific queue.

I tried the implementation with a join in `getPendingJobs`, but the performance tests were failing; this approach turned out to be the fastest. In the future, it would be useful to check the paused status not on every poll but at a lower interval.
Here as well, done is better than perfect...
