### PR TITLE
Incorrect pending dedup key index

### DIFF
--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -81,7 +81,7 @@ export function Database(logger: Logger, options: { uri: string; tablesPrefix?: 
       number: 5,
       up: `
         ALTER TABLE ${jobsTable()} ADD COLUMN pendingDedupKey VARCHAR(255) NULL;
-        ALTER TABLE ${jobsTable()} ADD UNIQUE INDEX idx_queue_name_pending_dedup (queueId, name, pendingDedupKey, status);
+        ALTER TABLE ${jobsTable()} ADD UNIQUE INDEX idx_queue_name_pending_dedup (queueId, name, (CASE WHEN status = 'pending' THEN pendingDedupKey ELSE NULL END));
       `,
     },
     {


### PR DESCRIPTION
This pr fixes a bug introduced by me in pr #56. I probably added the wrong index in my haste.

Before this pr, the (incorrect) index prevented two jobs with the same key from existing in a completed or failed state.

The idea of the `pendingDedupKey` parameter and its related index is to guarantee that there are not two jobs in a pending state with the same key. This logic should only apply during enqueue and must not in any way affect the management of jobs after enqueue.

In short, this operation should result in only one job being enqueued:
```typescript
await Promise.all([
    instance.enqueue("queue", { name: "job", payload: {}, pendingDedupKey: "foo" }),
    instance.enqueue("queue", { name: "job", payload: {}, pendingDedupKey: "foo" }),
]);
```


> [!WARNING]
> I purposely avoided adding a new migration and modified the original one. This should generally be avoided, but I’m certain we’re the only ones using `mysql-queue` right now, and I prefer to keep the number of migrations as low as possible.
 