### PR TITLE
feat: prometheus compatible metrics

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,10 +8,14 @@
     "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@types/node": "^22.13.15",
     "pino-pretty": "^13.1.2",
     "typescript": "^5.8.2",
     "vitest": "^3.1.1"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": ">=1.9.0"
   },
   "dependencies": {
     "cron-parser": "^5.4.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./types";
 import { createCleanup } from "./cleanup";
 import { createLeaderElection } from "./leaderElection";
+import { createMetrics } from "./metrics";
 import { createPeriodic } from "./periodic";
 import { createRescuer } from "./rescuer";
 import { Database } from "./database";
@@ -29,8 +30,13 @@ export function MysqlQueue(_options: Options) {
     tablesPrefix: options.tablesPrefix,
     uri: options.dbUri,
   });
-  const workersFactory = WorkersFactory(logger, database);
-  const rescuer = createRescuer(database, logger, { batchSize: options.rescuerBatchSize, rescueAfterMs: options.rescuerRescueAfterMs });
+  const metrics = createMetrics();
+  const workersFactory = WorkersFactory(logger, database, metrics);
+  const rescuer = createRescuer(database, logger, {
+    batchSize: options.rescuerBatchSize,
+    metrics,
+    rescueAfterMs: options.rescuerRescueAfterMs,
+  });
   const rescuerScheduler = createScheduler(rescuer.rescue, logger, {
     intervalMs: options.rescuerIntervalMs,
     runOnStart: options.rescuerRunOnStart,
@@ -174,6 +180,11 @@ export function MysqlQueue(_options: Options) {
     });
 
     const affectedRows = await database.addJobs(queueName, jobsForInsert, options.partitionKey, session);
+    if (affectedRows) {
+      const countsByName: Record<string, number> = {};
+      for (const job of jobsForInsert) countsByName[job.name] = (countsByName[job.name] ?? 0) + 1;
+      for (const [jobName, count] of Object.entries(countsByName)) metrics.jobsEnqueued(queueName, jobName, count);
+    }
     logger.debug({ jobCount: affectedRows, jobs: jobsForInsert }, "enqueue.jobsAddedToQueue");
     logger.info({ jobCount: affectedRows }, "enqueue.jobsAddedToQueue");
     return { enqueuedJobs: affectedRows, jobIds: jobsForInsert.map((j) => j.id) };

--- a/packages/core/src/jobProcessor.ts
+++ b/packages/core/src/jobProcessor.ts
@@ -3,6 +3,7 @@ import { Database } from "./database";
 import { errorToJson } from "./utils";
 import { executeJobsConcurrently } from "./concurrentJobProcessor";
 import { Logger } from "./logger";
+import { Metrics } from "./metrics";
 import { PoolConnection } from "mysql2/promise";
 
 export function JobProcessor(
@@ -21,6 +22,15 @@ export function JobProcessor(
 
       const jobs = await claimJobsForProcessing();
       if (!jobs) return false;
+      const claimedAt = Date.now();
+
+      for (const job of jobs) {
+        const eligibleAt = Math.max(job.createdAt.getTime(), job.startAfter.getTime());
+        options.metrics.jobQueueWaitTime(queue.name, job.name, (claimedAt - eligibleAt) / 1000);
+      }
+      for (const [jobName, count] of countByName(jobs)) {
+        options.metrics.jobsClaimed(queue.name, jobName, count);
+      }
 
       await Promise.all(
         jobs.map(async (job) => {
@@ -32,11 +42,24 @@ export function JobProcessor(
         }),
       );
 
+      const executionStart = Date.now();
       const result = await executeJobsConcurrently(jobs, options.callbackBatchSize, workerAbortSignal, executeCallbackWithTimeout);
+      const executionSeconds = (Date.now() - executionStart) / 1000;
 
-      await persistResults(result.successful.ids, result.failed);
+      await persistResults(result.successful, result.failed);
 
-      logger.debug({ elapsedSeconds: (Date.now() - start) / 1000, jobCount: jobs.length }, `jobProcessor.processed`);
+      for (const [jobName, count] of countByName(result.manuallyCompleted.jobs)) {
+        options.metrics.jobsCompleted(queue.name, jobName, count);
+      }
+
+      const allProcessedJobs = [...result.successful.jobs, ...result.manuallyCompleted.jobs, ...result.failed.flatMap((f) => f.jobs)];
+      for (const job of allProcessedJobs) {
+        options.metrics.jobExecutionTime(queue.name, job.name, executionSeconds);
+      }
+
+      const elapsedSeconds = (Date.now() - start) / 1000;
+      options.metrics.jobProcessingDuration(queue.name, elapsedSeconds);
+      logger.debug({ elapsedSeconds, jobCount: jobs.length }, `jobProcessor.processed`);
 
       await Promise.all(
         jobs.map(async (job) => {
@@ -102,14 +125,18 @@ export function JobProcessor(
     }
   }
 
-  async function persistResults(successfulJobIds: string[], failedJobsData: Array<{ ids: string[]; error: Error; jobs: Job[] }>) {
+  async function persistResults(
+    successful: { ids: string[]; jobs: Job[] },
+    failedJobsData: Array<{ ids: string[]; error: Error; jobs: Job[] }>,
+  ) {
     const terminalJobsToNotify: Array<{ error: Error; job: Job }> = [];
+    const retriedJobs: Job[] = [];
 
     await database.runWithPoolConnection(async (connection) => {
       await database.runTransaction(async (trx) => {
-        if (successfulJobIds.length > 0) {
-          await database.markJobsAsCompleted(connectionToSession(trx), successfulJobIds);
-          logger.debug({ jobIds: successfulJobIds }, `jobProcessor.jobsMarkedAsCompleted`);
+        if (successful.ids.length > 0) {
+          await database.markJobsAsCompleted(connectionToSession(trx), successful.ids);
+          logger.debug({ jobIds: successful.ids }, `jobProcessor.jobsMarkedAsCompleted`);
         }
 
         if (failedJobsData.length > 0) {
@@ -117,6 +144,7 @@ export function JobProcessor(
             await database.failJobs(trx, ids, queue.maxRetries, queue.minDelayMs, queue.backoffMultiplier, errorToJson(error));
             logger.error({ error: errorToJson(error), jobIds: ids }, `jobProcessor.processBatch.jobsChunkMarkedAsFailed`);
             const terminalJobs = chunkJobs.filter((j) => j.attempts + 1 >= queue.maxRetries);
+            retriedJobs.push(...chunkJobs.filter((j) => j.attempts + 1 < queue.maxRetries));
             terminalJobs.forEach((j) => {
               terminalJobsToNotify.push({ error, job: j });
             });
@@ -124,6 +152,16 @@ export function JobProcessor(
         }
       }, connection);
     });
+
+    for (const [jobName, count] of countByName(successful.jobs)) {
+      options.metrics.jobsCompleted(queue.name, jobName, count);
+    }
+    for (const [jobName, count] of countByName(terminalJobsToNotify.map((t) => t.job))) {
+      options.metrics.jobsFailed(queue.name, jobName, count);
+    }
+    for (const [jobName, count] of countByName(retriedJobs)) {
+      options.metrics.jobsRetried(queue.name, jobName, count);
+    }
 
     // Call onJobFailed hooks after transaction is closed
     await Promise.all(
@@ -136,6 +174,12 @@ export function JobProcessor(
       }),
     );
   }
+}
+
+function countByName(jobs: Job[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const job of jobs) counts.set(job.name, (counts.get(job.name) ?? 0) + 1);
+  return counts;
 }
 
 export function connectionToSession(connection: PoolConnection): Session {
@@ -153,6 +197,7 @@ export function connectionToSession(connection: PoolConnection): Session {
 
 export type JobProcessorOptions = {
   callbackBatchSize: number;
+  metrics: Metrics;
   onJobClaimed?: (job: JobWithQueueName) => void | Promise<void>;
   onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void | Promise<void>;
   onJobProcessed?: (job: JobWithQueueName) => void | Promise<void>;

--- a/packages/core/src/metrics.ts
+++ b/packages/core/src/metrics.ts
@@ -1,0 +1,54 @@
+import { metrics } from "@opentelemetry/api";
+
+export function createMetrics() {
+  const meter = metrics.getMeter("mysql-queue");
+
+  const jobsEnqueuedCounter = meter.createCounter("mysql_queue_jobs_enqueued_total", {
+    description: "Total number of jobs enqueued",
+  });
+  const jobsClaimedCounter = meter.createCounter("mysql_queue_jobs_claimed_total", {
+    description: "Total number of jobs claimed for processing",
+  });
+  const jobsCompletedCounter = meter.createCounter("mysql_queue_jobs_completed_total", {
+    description: "Total number of jobs completed successfully",
+  });
+  const jobsFailedCounter = meter.createCounter("mysql_queue_jobs_failed_total", {
+    description: "Total number of jobs that permanently failed",
+  });
+  const jobsRetriedCounter = meter.createCounter("mysql_queue_jobs_retried_total", {
+    description: "Total number of jobs retried after failure",
+  });
+  const jobsRescuedCounter = meter.createCounter("mysql_queue_jobs_rescued_total", {
+    description: "Total number of stuck jobs rescued",
+  });
+  const workersActiveCounter = meter.createUpDownCounter("mysql_queue_workers_active", {
+    description: "Number of currently active workers",
+  });
+  const jobQueueWaitHistogram = meter.createHistogram("mysql_queue_job_queue_wait_seconds", {
+    description: "Time from job eligibility (max(createdAt, startAfter)) to claim",
+  });
+  const jobExecutionHistogram = meter.createHistogram("mysql_queue_job_execution_seconds", {
+    description: "Time from claim to completion/failure per job",
+  });
+  const jobProcessingHistogram = meter.createHistogram("mysql_queue_job_processing_seconds", {
+    description: "Duration of job batch processing in seconds",
+  });
+
+  return {
+    jobExecutionTime: (queue: string, jobName: string, seconds: number) =>
+      jobExecutionHistogram.record(seconds, { job_name: jobName, queue }),
+    jobProcessingDuration: (queue: string, seconds: number) => jobProcessingHistogram.record(seconds, { queue }),
+    jobQueueWaitTime: (queue: string, jobName: string, seconds: number) =>
+      jobQueueWaitHistogram.record(seconds, { job_name: jobName, queue }),
+    jobsClaimed: (queue: string, jobName: string, count: number) => jobsClaimedCounter.add(count, { job_name: jobName, queue }),
+    jobsCompleted: (queue: string, jobName: string, count: number) => jobsCompletedCounter.add(count, { job_name: jobName, queue }),
+    jobsEnqueued: (queue: string, jobName: string, count: number) => jobsEnqueuedCounter.add(count, { job_name: jobName, queue }),
+    jobsFailed: (queue: string, jobName: string, count: number) => jobsFailedCounter.add(count, { job_name: jobName, queue }),
+    jobsRescued: (count: number) => jobsRescuedCounter.add(count),
+    jobsRetried: (queue: string, jobName: string, count: number) => jobsRetriedCounter.add(count, { job_name: jobName, queue }),
+    workerStarted: (queue: string) => workersActiveCounter.add(1, { queue }),
+    workerStopped: (queue: string) => workersActiveCounter.add(-1, { queue }),
+  };
+}
+
+export type Metrics = ReturnType<typeof createMetrics>;

--- a/packages/core/src/rescuer.ts
+++ b/packages/core/src/rescuer.ts
@@ -1,9 +1,10 @@
 import { Database } from "./database";
 import { Logger } from "./logger";
+import { Metrics } from "./metrics";
 import { RowDataPacket } from "mysql2/promise";
 
 export function createRescuer(database: Database, logger: Logger, options: RescuerOptions) {
-  const { batchSize, rescueAfterMs } = options;
+  const { batchSize, metrics, rescueAfterMs } = options;
 
   return {
     async rescue() {
@@ -29,6 +30,7 @@ export function createRescuer(database: Database, logger: Logger, options: Rescu
         );
 
         logger.debug({ jobsCount: stuckJobs.length, queuesCount: Object.keys(jobsByQueue).length }, "rescuer.foundStuckJobs");
+        metrics.jobsRescued(stuckJobs.length);
 
         for (const [queueId, jobIds] of Object.entries(jobsByQueue)) {
           const queue = await database.getQueueById(connection, queueId);
@@ -46,6 +48,7 @@ export function createRescuer(database: Database, logger: Logger, options: Rescu
 }
 
 interface RescuerOptions {
-  rescueAfterMs: number;
   batchSize: number;
+  metrics: Metrics;
+  rescueAfterMs: number;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,7 @@ export interface Job {
   createdAt: Date;
   completedAt: Date | null;
   failedAt: Date | null;
+  runningAt: Date | null;
   attempts: number;
   latestFailureReason: string | null;
   queueId: string;

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -3,9 +3,10 @@ import { JobWithQueueName, Queue, WorkerCallback } from "./types";
 import { Database } from "./database";
 import { errorToJson } from "./utils";
 import { Logger } from "./logger";
+import { Metrics } from "./metrics";
 import { randomUUID } from "node:crypto";
 
-export function WorkersFactory(logger: Logger, database: Database) {
+export function WorkersFactory(logger: Logger, database: Database, metrics: Metrics) {
   const jobExecutionTrackers: Record<string, { remaining: number; promise: (job: JobWithQueueName) => void }> = {};
   const workers: Worker[] = [];
 
@@ -23,6 +24,7 @@ export function WorkersFactory(logger: Logger, database: Database) {
     ) {
       const worker = Worker(database, callback, queue, logger, {
         ...options,
+        metrics,
         onJobProcessed: (job) => {
           const tracker = jobExecutionTrackers[queue.name];
           if (tracker) {
@@ -78,6 +80,7 @@ export function Worker(database: Database, callback: WorkerCallback, queue: Queu
         `worker.starting`,
       );
 
+      options.metrics.workerStarted(queue.name);
       while (!signal.aborted) {
         try {
           const hadJobs = await jobProcessor.process();
@@ -87,6 +90,7 @@ export function Worker(database: Database, callback: WorkerCallback, queue: Queu
           wLogger.error({ error: errorToJson(typedError) }, `worker.loop.error`);
         }
       }
+      options.metrics.workerStopped(queue.name);
       stopPromiseResolve?.();
       wLogger.debug(`worker.aborted`);
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
         specifier: ^9.6.0
         version: 9.6.0
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       '@types/node':
         specifier: ^22.13.15
         version: 22.13.15
@@ -155,10 +158,10 @@ importers:
         version: 3.14.5
       next:
         specifier: 15.3.6
-        version: 15.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.3.6(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 4.24.11(next@15.3.6(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1160,6 +1163,10 @@ packages:
 
   '@octokit/types@14.1.0':
     resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
@@ -5479,6 +5486,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.1.0
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@panva/hkdf@1.2.1': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -7712,13 +7721,13 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.11(next@15.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next-auth@4.24.11(next@15.3.6(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.3.6(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.27.2
@@ -7732,7 +7741,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  next@15.3.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.3.6(@opentelemetry/api@1.9.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.3.6
       '@swc/counter': 0.1.3
@@ -7752,6 +7761,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.5
       '@next/swc-win32-arm64-msvc': 15.3.5
       '@next/swc-win32-x64-msvc': 15.3.5
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
Adds OpenTelemetry-native instrumentation to `mysql-queue` using `@opentelemetry/api` as a peer dependency. Operators running the library in production had no visibility into throughput, latency, or failure rates — metrics now flow through whatever OTel SDK pipeline the user already has configured (Datadog, Grafana Cloud, Honeycomb, etc.), with no extra scraping infrastructure needed. For apps without OTel, the API is a no-op with zero overhead.

**TLDR**

- `metrics.ts` (new): thin wrapper over `@opentelemetry/api` — creates a meter named `mysql-queue` and registers all instruments at startup; zero custom rendering code
- `@opentelemetry/api >=1.7.0` added as a peer dependency (dev dep for type-checking; no-op at runtime if no SDK is installed)
- 8 job lifecycle counters: `enqueued`, `claimed`, `completed`, `failed`, `retried`, `rescued` (all labeled `queue` + `job_name` except `rescued` which has no name context in the DB query)
- 1 up-down counter: `mysql_queue_workers_active` per queue, incremented/decremented around the worker poll loop
- 3 histograms with explicit bucket boundaries: `job_queue_wait_seconds` (eligibility → claim, exact per-job), `job_execution_seconds` (claim → callback completion), `job_processing_seconds` (full batch wall-clock)
- `runningAt: Date | null` added to the `Job` type — already present in the DB schema, was missing from the TypeScript interface

**Notes**

- `renderPrometheusMetrics()` is removed from the public API — Prometheus users should configure `@opentelemetry/exporter-prometheus` in their SDK setup instead
- `jobsEnqueued` counts from `jobsForInsert` so it may overcount when `idempotentKey`/`pendingDedupKey` deduplication skips jobs — the DB layer does not return which specific jobs were inserted vs. skipped
- `jobsRescued` is incremented before the per-queue `failJobs` loop completes; a mid-rescue DB error would leave the counter slightly overcounted for that batch
- `jobExecutionTime` is the same value for all jobs in a concurrent batch (wall-clock after `onJobClaimed` hooks, before DB persistence) — per-job precision would require per-chunk instrumentation