### PR TITLE
fix(ui): periodic jobs last run

### DIFF
--- a/packages/ui/components/periodic-jobs-table.tsx
+++ b/packages/ui/components/periodic-jobs-table.tsx
@@ -23,10 +23,10 @@ const periodicJobColumns: ColumnDef<PeriodicJob>[] = [
     ),
   },
   {
-    accessorKey: "lastEnqueuedAt",
-    header: "Last Enqueued",
+    accessorKey: "lastRunAt",
+    header: "Last Run",
     cell: ({ row }) => (
-      <span className="text-xs">{row.original.lastEnqueuedAt ? <LiveTime date={new Date(row.original.lastEnqueuedAt)} /> : "Never"}</span>
+      <span className="text-xs">{row.original.lastRunAt ? <LiveTime date={new Date(row.original.lastRunAt)} /> : "Never"}</span>
     ),
   },
   {

--- a/packages/ui/lib/db-types.ts
+++ b/packages/ui/lib/db-types.ts
@@ -50,7 +50,7 @@ export type GetJobsParams = {
 
 export type DbPeriodicJob = {
   name: string;
-  lastEnqueuedAt: Date | null;
+  lastRunAt: Date | null;
   nextRunAt: Date;
   createdAt: Date;
   updatedAt: Date;

--- a/packages/ui/lib/db.ts
+++ b/packages/ui/lib/db.ts
@@ -402,7 +402,7 @@ export async function getPeriodicJobs(dbUri: string) {
       createdAt: row.createdAt.toISOString(),
       cronExpression: row.definition?.cronExpression,
       definition: row.definition,
-      lastEnqueuedAt: row.lastEnqueuedAt ? row.lastEnqueuedAt.toISOString() : null,
+      lastRunAt: row.lastRunAt ? row.lastRunAt.toISOString() : null,
       name: row.name,
       nextRunAt: row.nextRunAt.toISOString(),
       targetQueue: row.definition?.targetQueue,

--- a/packages/ui/types/periodic-job.ts
+++ b/packages/ui/types/periodic-job.ts
@@ -2,7 +2,7 @@ export type PeriodicJob = {
   name: string;
   cronExpression?: string;
   targetQueue?: string;
-  lastEnqueuedAt: string | null;
+  lastRunAt: string | null;
   nextRunAt: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
The periodic jobs table was referencing _lastEnqueuedAt_, a column that does not exist in the database. This fix corrects it to use the actual lastRunAt column, so the Last Run timestamp now displays correctly instead of always showing Never.

**TLDR**

- Replaced non-existent lastEnqueuedAt references with the actual lastRunAt column across types, DB query, and table component
- Renamed the column header from "Last Enqueued" to "Last Run" to match the field semantics