### PR TITLE
feat(worker): include job name in onJobFailed hook

### DIFF
--- a/packages/core/src/jobProcessor.ts
+++ b/packages/core/src/jobProcessor.ts
@@ -138,7 +138,7 @@ export function JobProcessor(
     await Promise.all(
       terminalJobsToNotify.map(async ({ error, job }) => {
         try {
-          await options.onJobFailed?.(error, { id: job.id, queueName: queue.name });
+          await options.onJobFailed?.(error, { id: job.id, name: job.name, queueName: queue.name });
         } catch (hookError) {
           logger.error({ error: errorToJson(hookError as Error), jobId: job.id }, `jobProcessor.onJobFailed.error`);
         }
@@ -163,7 +163,7 @@ export function connectionToSession(connection: PoolConnection): Session {
 export type JobProcessorOptions = {
   callbackBatchSize: number;
   onJobClaimed?: (job: JobWithQueueName) => void | Promise<void>;
-  onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void | Promise<void>;
+  onJobFailed?: (error: Error, job: { id: string; name: string; queueName: string }) => void | Promise<void>;
   onJobProcessed?: (job: JobWithQueueName) => void | Promise<void>;
   pollingBatchSize: number;
   pollingIntervalMs: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -114,7 +114,7 @@ export interface PeriodicJob {
 export type WorkOptions = {
   callbackBatchSize?: number;
   onJobClaimed?: (job: JobWithQueueName) => void | Promise<void>;
-  onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void | Promise<void>;
+  onJobFailed?: (error: Error, job: { id: string; name: string; queueName: string }) => void | Promise<void>;
   pollingBatchSize?: number;
   pollingIntervalMs?: number;
 };

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -16,7 +16,7 @@ export function WorkersFactory(logger: Logger, database: Database) {
       options: {
         callbackBatchSize: number;
         onJobClaimed?: (job: JobWithQueueName) => void | Promise<void>;
-        onJobFailed?: (error: Error, job: { id: string; queueName: string }) => void | Promise<void>;
+        onJobFailed?: (error: Error, job: { id: string; name: string; queueName: string }) => void | Promise<void>;
         pollingBatchSize: number;
         pollingIntervalMs: number;
       },

--- a/packages/core/tests/workers.test.ts
+++ b/packages/core/tests/workers.test.ts
@@ -231,7 +231,7 @@ describe("workers", () => {
       await promise;
 
       expect(OnJobFailedMock).toHaveBeenCalledTimes(1);
-      expect(OnJobFailedMock).toHaveBeenCalledWith(error, { id: jobId, queueName });
+      expect(OnJobFailedMock).toHaveBeenCalledWith(error, { id: jobId, name: "1", queueName });
     });
 
     it("should call onJobClaimed once per claimed job before the handler runs", async () => {


### PR DESCRIPTION
## Context

When a job fails and the error is reported to Sentry through the `onJobFailed` hook, we only get the job `id` and the `queueName`. That's been a constant friction in practice: every time an exception comes in, we have to jump back to the database (or to the queue UI) and look up which job it actually was. It is especially painful on queues like `invoicing` that host many different job types behind a single queue, where the queue name alone tells us almost nothing about what was running.

This PR makes the hook a bit more useful by including the job `name` directly in the payload passed to `onJobFailed`. With that small addition, consumers can attach the job name as a Sentry tag/context, group errors by job type, and skip the manual lookup entirely.

## Changes

- `onJobFailed` now receives `{ id, name, queueName }` instead of `{ id, queueName }`
- Updated the related TypeScript types in `types.ts`, `jobProcessor.ts`, and `worker.ts`
- Updated the existing `workers.test.ts` assertion to reflect the new shape

## Breaking change

This is a breaking change for anyone implementing the `onJobFailed` hook with a strict signature. A minor version bump is recommended.

