### PR TITLE
perf(cleanup): remove ORDER BY to eliminate per-batch filesort

### DIFF
--- a/packages/core/src/cleanup.ts
+++ b/packages/core/src/cleanup.ts
@@ -10,6 +10,7 @@ export function createCleanup(database: Database, logger: Logger, options: Clean
       let iterations = 0;
       let deleted: number;
 
+      const startedAt = Date.now();
       do {
         deleted = await database.deleteCompletedJobsOlderThan(partitionKey, retentionDays, batchSize);
         totalDeleted += deleted;
@@ -17,7 +18,7 @@ export function createCleanup(database: Database, logger: Logger, options: Clean
       } while (iterations < maxIterationsForRun && deleted >= batchSize);
 
       if (totalDeleted > 0) {
-        logger.info({ batchCount: iterations, totalDeleted }, "cleanup.completedJobsDeleted");
+        logger.info({ batchCount: iterations, durationMs: Date.now() - startedAt, totalDeleted }, "cleanup.completedJobsDeleted");
       } else {
         logger.debug("cleanup.noCompletedJobsToDelete");
       }

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -285,9 +285,7 @@ export function Database(logger: Logger, options: { uri: string; tablesPrefix?: 
                INNER JOIN ${queuesTable()} q ON j2.queueId = q.id
                WHERE q.partitionKey = ?
                  AND j2.status = 'completed'
-                 AND j2.completedAt IS NOT NULL
                  AND j2.completedAt < DATE_SUB(NOW(3), INTERVAL COALESCE(q.jobsRetentionDays, ?) DAY)
-               ORDER BY j2.completedAt ASC, j2.id ASC
                LIMIT ?
              ) AS j
            )`,


### PR DESCRIPTION
The completed-jobs cleanup was stalling worker job claims.
Its delete query ordered by `completedAt`, which forced MySQL into a temp table + filesort over the entire eligible set on every batch (a `LIMIT` cannot be pushed past a sort) — roughly 6s per 1000-row batch regardless of how much it actually deleted, holding the shared connection pool long enough to starve `SELECT … FOR UPDATE` claims. Removing the `ORDER BY` lets the nested-loop join use the existing `(queueId, status, …)` index and stop at `LIMIT`, eliminating the per-batch sort.

**TLDR**

- Removed `ORDER BY completedAt ASC, id ASC` from the cleanup delete query — ordering is irrelevant for cleanup, and it was the sole cause of the `Using temporary; Using filesort` plan.
- Dropped the now-redundant `completedAt IS NOT NULL` predicate (a `completedAt < …` range already excludes NULLs).

**Notes**

- `EXPLAIN` before vs after confirms the fix: the driving table's `Extra` goes from `Using where; Using temporary; Using filesort` to just `Using where`; the join uses the existing `idx_queueId_status_startAfter_createdAt_priority_id` index.
